### PR TITLE
Implement schema-aware LLM prompts and retry logic

### DIFF
--- a/data-agent/app/ui_streamlit.py
+++ b/data-agent/app/ui_streamlit.py
@@ -175,12 +175,14 @@ with st.expander("LLM → code → safe_exec"):
         if nl_q.strip():
             with st.spinner("Thinking..."):
                 try:
-                    code = ask_llm(nl_q, tuple(df.columns))
+                    intent, code = ask_llm(nl_q, df)
                 except Exception as e:
                     st.error("LLM call failed.")
                     if debug:
                         st.exception(e)
                 else:
+                    if intent:
+                        st.caption(intent)
                     st.code(code, language="python")
                     ok, result, tb = safe_ui(safe_run)(code, {"df": df, "pd": pd, "plt": plt})
                     if ok:

--- a/tests/test_llm_driver.py
+++ b/tests/test_llm_driver.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from app.core.llm_driver import _schema_desc, _extract_json
+
+
+def test_schema_desc():
+    df = pd.DataFrame({
+        "num": [1, 2, 3],
+        "cat": ["a", "b", "a"],
+    })
+    desc = _schema_desc(df)
+    assert "num" in desc
+    assert "int" in desc
+    assert "cat" in desc
+
+
+def test_extract_json():
+    intent, code = _extract_json('{"intent": "do", "code": "print(1)"}')
+    assert intent == "do"
+    assert code == "print(1)"


### PR DESCRIPTION
## Summary
- make llm_driver include schema information
- return intent and code in JSON
- retry LLM when AST validation fails
- display intent in Streamlit UI
- add tests for new helpers

## Testing
- `pip install --break-system-packages -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd9e713788329b623efd916ab06e9