### PR TITLE
Add safety hardening and privacy features

### DIFF
--- a/data-agent/app/core/file_loader.py
+++ b/data-agent/app/core/file_loader.py
@@ -1,9 +1,23 @@
-import pandas as pd
+import os
 from pathlib import Path
-from typing import Union, IO
+from typing import IO, Union
+
+import pandas as pd
+
+DATA_DIR = Path(os.environ.get("DATA_DIR", "data"))
+
+
+def _maybe_cache(file: IO[bytes], name: str) -> None:
+    if os.environ.get("NO_CACHE_MODE") not in {"1", "true", "True"}:
+        DATA_DIR.mkdir(exist_ok=True)
+        dest = DATA_DIR / Path(name).name
+        dest.write_bytes(file.read())
+        file.seek(0)
 
 def load_any(file: Union[str, Path, IO[bytes]]) -> pd.DataFrame:
     name = getattr(file, "name", str(file))
+    if hasattr(file, "read"):
+        _maybe_cache(file, name)
     if name.endswith(".csv"):
         return pd.read_csv(file)
     if name.endswith((".xls", ".xlsx")):

--- a/data-agent/app/core/safe_exec.py
+++ b/data-agent/app/core/safe_exec.py
@@ -1,9 +1,16 @@
 import ast
 import builtins
-from types import CodeType
-from io import StringIO
 import contextlib
+import multiprocessing as mp
+import signal
+from io import StringIO
+from types import CodeType
 from typing import Any, Dict, Tuple
+
+try:  # resource is Unix only
+    import resource
+except Exception:  # pragma: no cover - windows
+    resource = None  # type: ignore
 
 ALLOWED_NODES = {
     ast.Module, ast.Expr, ast.Assign, ast.AugAssign,
@@ -37,12 +44,23 @@ def _analyze(code_str: str) -> ast.Module:
     return tree
 
 
-def run(code: str, context: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
-    tree = _analyze(code)
+def _worker(code_str: str, context: Dict[str, Any], q: mp.Queue, timeout: int) -> None:
+    """Execute code in a separate process and put results on queue."""
+    tree = _analyze(code_str)
     compiled: CodeType = compile(tree, filename="<safe_exec>", mode="exec")
 
-    safe_builtins = {k: getattr(builtins, k) for k in ALLOWED_BUILTINS}
+    if resource is not None:
+        # limit CPU seconds roughly equal to timeout
+        resource.setrlimit(resource.RLIMIT_CPU, (timeout, timeout))
 
+    def _alarm_handler(signum, frame):  # pragma: no cover - relies on OS
+        raise TimeoutError("Time limit exceeded")
+
+    if hasattr(signal, "SIGALRM"):
+        signal.signal(signal.SIGALRM, _alarm_handler)
+        signal.alarm(timeout)
+
+    safe_builtins = {k: getattr(builtins, k) for k in ALLOWED_BUILTINS}
     safe_globals: Dict[str, Any] = {"__builtins__": safe_builtins}
     safe_globals.update(context)
 
@@ -51,6 +69,21 @@ def run(code: str, context: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
     with contextlib.redirect_stdout(stdout_buffer):
         exec(compiled, safe_globals, local_vars)
 
-    return local_vars, stdout_buffer.getvalue()
+    q.put((local_vars, stdout_buffer.getvalue()))
+
+
+def run(code: str, context: Dict[str, Any], timeout: int = 5) -> Tuple[Dict[str, Any], str]:
+    """Safely execute code with a time limit."""
+    q: mp.Queue = mp.Queue()
+    proc = mp.Process(target=_worker, args=(code, context, q, timeout))
+    proc.start()
+    proc.join(timeout)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        raise TimeoutError("Execution timed out")
+    if not q.empty():
+        return q.get()
+    return {}, ""
 
 

--- a/tests/test_file_loader.py
+++ b/tests/test_file_loader.py
@@ -1,0 +1,17 @@
+import io
+import os
+from pathlib import Path
+
+import pandas as pd
+import importlib
+
+
+def test_no_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv("NO_CACHE_MODE", "1")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    fl = importlib.import_module("app.core.file_loader")
+    buf = io.BytesIO(b"a,b\n1,2\n")
+    buf.name = "t.csv"
+    df = fl.load_any(buf)
+    assert isinstance(df, pd.DataFrame)
+    assert not any(tmp_path.iterdir())

--- a/tests/test_llm_driver.py
+++ b/tests/test_llm_driver.py
@@ -13,6 +13,12 @@ def test_schema_desc():
     assert "cat" in desc
 
 
+def test_schema_desc_redact():
+    df = pd.DataFrame({"name": ["a"], "age": [1]})
+    desc = _schema_desc(df, redact_cols=["name"])
+    assert "<redacted>" in desc
+
+
 def test_extract_json():
     intent, code = _extract_json('{"intent": "do", "code": "print(1)"}')
     assert intent == "do"

--- a/tests/test_safe_exec.py
+++ b/tests/test_safe_exec.py
@@ -1,0 +1,24 @@
+import pytest
+
+from app.core.safe_exec import _analyze, run
+
+
+def test_analyze_disallows_import():
+    with pytest.raises(ValueError):
+        _analyze("import os")
+
+
+def test_analyze_disallows_exec_call():
+    with pytest.raises(ValueError):
+        _analyze("exec('print(1)')")
+
+
+def test_run_timeout():
+    with pytest.raises(TimeoutError):
+        run("while True:\n    pass", {}, timeout=1)
+
+
+def test_run_simple():
+    locals_out, stdout = run("x=1\nprint('ok')", {}, timeout=2)
+    assert locals_out["x"] == 1
+    assert stdout.strip() == "ok"


### PR DESCRIPTION
## Summary
- support DataFrame schema redaction for PII columns
- add optional caching for uploaded files
- harden safe_exec with subprocess timeouts
- test file loader no-cache behavior
- test safe exec allow list and timeout cases
- test schema redaction logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687feb7a02008329ad1f7da139ee896a