### PR TITLE
Add React frontend prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .venv/
 *.pyc
 __pycache__/
+
+# Node
+node_modules/
+frontend/node_modules/
+frontend/dist/

--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ Choose a permissive OSS license (MIT or Apache-2.0) unless you have constraints.
 Initial concept and implementation:&#x20;
 
 ---
+## 14. React UI Prototype
+
+An experimental React + Vite frontend lives under `frontend/`. It uses
+MUI components together with Recharts for interactive charts. Run `npm install` and then `npm run dev` inside that directory to start
+the development server.
+
 
 Happy building.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Data Agent UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "data-agent-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.0",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^5.15.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.8.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Container, Typography } from '@mui/material';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+const data = [
+  { name: 'A', value: 12 },
+  { name: 'B', value: 18 },
+  { name: 'C', value: 5 }
+];
+
+export default function App() {
+  return (
+    <Container sx={{ marginTop: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Data Agent React UI
+      </Typography>
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={data}>
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey="value" fill="#1976d2" />
+        </BarChart>
+      </ResponsiveContainer>
+    </Container>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- ignore Node build folders
- scaffold experimental React + Vite frontend using MUI and Recharts
- document the new prototype in the README

## Testing
- `make test` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6880474461a08329874336d77f021a66