### PR TITLE
Implement persistence layer and API models

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Data Agent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/data-agent/app/api.py
+++ b/data-agent/app/api.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import base64
 import io
+from pathlib import Path
 from typing import Any, Dict
+import uuid
 
 import matplotlib.pyplot as plt
 import pandas as pd
-from fastapi import FastAPI, File, UploadFile
+from fastapi import FastAPI, File, UploadFile, Request
 from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel
 
 from .core.analysis import basic_summary
 from .core.charts import (
@@ -24,39 +27,101 @@ from .core.file_loader import load_any
 from .core.llm_driver import ask_llm
 from .services.postprocess import extract_outputs, figure_to_png
 from .services.safe_exec import run as safe_run
+from .core.storage import add_dataset, get_dataset_path, init_db
+from .core.error_utils import logger
+import traceback
+
+
+class UploadResponse(BaseModel):
+    dataset_id: str
+    rows: int
+
+
+class SummaryResponse(BaseModel):
+    rows: int
+    columns: list[str]
+    dtypes: dict[str, str]
+    null_counts: dict[str, int]
+
+
+class ChartSpec(BaseModel):
+    type: str
+    params: dict[str, Any] | None = None
+
+
+class NL2CodeRequest(BaseModel):
+    question: str
+
+
+class NL2CodeResponse(BaseModel):
+    intent: str
+    code: str
+
+
+class RunCodeRequest(BaseModel):
+    code: str
+
+
+class RunCodeResponse(BaseModel):
+    stdout: str
+    tables: list[str]
+    images: list[str]
+    texts: list[str]
 
 app = FastAPI(title="Data Agent API")
 
 DATASETS: Dict[str, pd.DataFrame] = {}
+init_db()
+
+
+@app.exception_handler(Exception)
+async def _unhandled(request: Request, exc: Exception):
+    tb = traceback.format_exc()
+    logger.error("Unhandled error: %s\n%s", exc, tb)
+    return JSONResponse(status_code=500, content={"error": "internal server error"})
 
 
 @app.post("/upload")
-async def upload(file: UploadFile = File(...)) -> Dict[str, Any]:
+async def upload(file: UploadFile = File(...)) -> UploadResponse:
     data = await file.read()
+    ds_path = Path("data")
+    ds_path.mkdir(exist_ok=True)
+    ds_id = str(uuid.uuid4())
+    path = ds_path / f"{ds_id}_{Path(file.filename).name}"
+    add_dataset(str(path), ds_id)
+    with open(path, "wb") as f:
+        f.write(data)
     buf = io.BytesIO(data)
     buf.name = file.filename
     df = load_any(buf)
-    ds_id = str(len(DATASETS) + 1)
     DATASETS[ds_id] = df
-    return {"dataset_id": ds_id, "rows": len(df)}
+    return UploadResponse(dataset_id=ds_id, rows=len(df))
 
 
-@app.get("/summary/{ds_id}")
+@app.get("/summary/{ds_id}", response_model=SummaryResponse)
 def summary(ds_id: str):
     df = DATASETS.get(ds_id)
     if df is None:
-        return JSONResponse(status_code=404, content={"error": "dataset not found"})
-    return basic_summary(df)
+        try:
+            df = load_any(get_dataset_path(ds_id))
+        except Exception:
+            return JSONResponse(status_code=404, content={"error": "dataset not found"})
+        DATASETS[ds_id] = df
+    return SummaryResponse(**basic_summary(df))
 
 
 @app.post("/chart/{ds_id}")
-async def chart(ds_id: str, spec: Dict[str, Any]):
+async def chart(ds_id: str, spec: ChartSpec):
     df = DATASETS.get(ds_id)
     if df is None:
-        return JSONResponse(status_code=404, content={"error": "dataset not found"})
+        try:
+            df = load_any(get_dataset_path(ds_id))
+        except Exception:
+            return JSONResponse(status_code=404, content={"error": "dataset not found"})
+        DATASETS[ds_id] = df
 
-    chart_type = spec.get("type")
-    params = spec.get("params", {})
+    chart_type = spec.type
+    params = spec.params or {}
 
     if chart_type == "line":
         png = line_plot(df, **params)
@@ -80,26 +145,33 @@ async def chart(ds_id: str, spec: Dict[str, Any]):
     return StreamingResponse(png, media_type="image/png")
 
 
-@app.post("/nl2code/{ds_id}")
-async def nl2code(ds_id: str, payload: Dict[str, str]):
+@app.post("/nl2code/{ds_id}", response_model=NL2CodeResponse)
+async def nl2code(ds_id: str, payload: NL2CodeRequest):
     df = DATASETS.get(ds_id)
     if df is None:
-        return JSONResponse(status_code=404, content={"error": "dataset not found"})
-    question = payload.get("question", "")
-    intent, code = ask_llm(question, df)
-    return {"intent": intent, "code": code}
+        try:
+            df = load_any(get_dataset_path(ds_id))
+        except Exception:
+            return JSONResponse(status_code=404, content={"error": "dataset not found"})
+        DATASETS[ds_id] = df
+    intent, code = ask_llm(payload.question, df)
+    return NL2CodeResponse(intent=intent, code=code)
 
 
-@app.post("/run_code/{ds_id}")
-async def run_code(ds_id: str, payload: Dict[str, str]):
+@app.post("/run_code/{ds_id}", response_model=RunCodeResponse)
+async def run_code(ds_id: str, payload: RunCodeRequest) -> RunCodeResponse:
     df = DATASETS.get(ds_id)
     if df is None:
-        return JSONResponse(status_code=404, content={"error": "dataset not found"})
-    code = payload.get("code", "")
+        try:
+            df = load_any(get_dataset_path(ds_id))
+        except Exception:
+            return JSONResponse(status_code=404, content={"error": "dataset not found"})
+        DATASETS[ds_id] = df
+    code = payload.code
     locals_out, stdout = safe_run(code, {"df": df, "pd": pd, "plt": plt})
     dfs, pngs, figs, texts = extract_outputs(locals_out)
     for fig in figs:
         pngs.append(figure_to_png(fig))
     tables = [df_out.to_csv(index=False) for df_out in dfs]
     images = [base64.b64encode(p.getvalue()).decode() for p in pngs]
-    return {"stdout": stdout, "tables": tables, "images": images, "texts": texts}
+    return RunCodeResponse(stdout=stdout, tables=tables, images=images, texts=texts)

--- a/data-agent/app/core/storage.py
+++ b/data-agent/app/core/storage.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+DB_FILE = Path(__file__).resolve().parents[2] / "datasets.db"
+DB_FILE.parent.mkdir(exist_ok=True)
+
+
+def init_db() -> None:
+    with sqlite3.connect(DB_FILE) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS datasets (id TEXT PRIMARY KEY, path TEXT NOT NULL)"
+        )
+
+
+def add_dataset(path: str, ds_id: str | None = None) -> str:
+    import uuid
+
+    if ds_id is None:
+        ds_id = str(uuid.uuid4())
+    with sqlite3.connect(DB_FILE) as conn:
+        conn.execute("INSERT INTO datasets (id, path) VALUES (?, ?)", (ds_id, path))
+    return ds_id
+
+
+def get_dataset_path(ds_id: str) -> Path:
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.execute("SELECT path FROM datasets WHERE id=?", (ds_id,))
+        row = cur.fetchone()
+    if row is None:
+        raise KeyError(ds_id)
+    return Path(row[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,41 @@
+[project]
+name = "data-agent"
+version = "0.1.0"
+description = "Local data summarization and charting API"
+requires-python = ">=3.11"
+authors = [
+    {name = "Data Agent", email = "noreply@example.com"}
+]
+dependencies = [
+    "pandas>=2.2",
+    "matplotlib>=3.9",
+    "numpy>=1.26",
+    "openpyxl>=3.1",
+    "reportlab>=4.0",
+    "python-pptx>=0.6"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pre-commit",
+    "ruff",
+    "isort",
+    "mypy",
+    "pyproject-fmt",
+    "pytest"
+]
+
 [tool.mypy]
 python_version = "3.11"
 files = ["data-agent/app/core"]
 check_untyped_defs = true
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+addopts = "-q"
+
+[tool.ruff]
+line-length = 88
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
## Summary
- add MIT license
- expand pyproject metadata with build configs
- persist uploaded datasets to SQLite via new storage module
- add Pydantic models and error handling in FastAPI API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6880884e55a08329b2a8f7abf7b959a3