### PR TITLE
Implement conversation-aware LLM caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ root/
 4. Validate AST for allowed nodes (Import, Call, Assign, etc.).
 5. Execute and capture DataFrame or Figure objects.
 6. Return result to UI.
+7. Cache previous questions and reuse answers when possible.
+8. Include recent conversation history in the prompt for better context.
 
 ---
 


### PR DESCRIPTION
## Summary
- refine system prompt for local LLM usage
- cache question results and maintain short conversation history
- embed conversation history in prompts
- update Local LLM Integration Plan in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688090f999f883298b270b0f1f9bc810