### PR TITLE
Expand React UI for dataset summaries and history

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.15.0",
+    "@mui/icons-material": "^5.15.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.8.0"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,33 +1,86 @@
-import React, { useState } from 'react';
-import { Container, Typography, Box } from '@mui/material';
+import React, { useMemo, useState } from 'react';
+import {
+  Container,
+  Typography,
+  Box,
+  CssBaseline,
+  createTheme,
+  ThemeProvider,
+  IconButton,
+} from '@mui/material';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
 import FileUpload from './FileUpload';
-import { fetchChart } from './api';
+import DatasetSummary from './DatasetSummary';
+import ChartBuilder from './ChartBuilder';
+import HistoryPanel from './HistoryPanel';
 
 export default function App() {
   const [datasetId, setDatasetId] = useState<string | null>(null);
+  const [columns, setColumns] = useState<string[]>([]);
   const [chartUrl, setChartUrl] = useState<string | null>(null);
+  const [mode, setMode] = useState<'light' | 'dark'>(() =>
+    (localStorage.getItem('theme') as 'light' | 'dark') || 'light'
+  );
+
+  const theme = useMemo(
+    () =>
+      createTheme({
+        palette: { mode },
+      }),
+    [mode]
+  );
+
+  const toggleTheme = () => {
+    const next = mode === 'light' ? 'dark' : 'light';
+    setMode(next);
+    localStorage.setItem('theme', next);
+  };
 
   const handleUploaded = async (id: string) => {
     setDatasetId(id);
-    try {
-      const url = await fetchChart(id, { type: 'bar', params: {} });
-      setChartUrl(url);
-    } catch {
-      setChartUrl(null);
-    }
+    setChartUrl(null);
   };
 
+  React.useEffect(() => {
+    if (!datasetId) return;
+    import('./api').then(({ fetchSummary }) =>
+      fetchSummary(datasetId)
+        .then((s) => setColumns(s.columns))
+        .catch(() => setColumns([]))
+    );
+  }, [datasetId]);
+
   return (
-    <Container sx={{ marginTop: 4 }}>
-      <Typography variant="h4" gutterBottom>
-        Data Agent React UI
-      </Typography>
-      <Box sx={{ mb: 2 }}>
-        <FileUpload onUploaded={handleUploaded} />
-      </Box>
-      {datasetId && chartUrl && (
-        <img src={chartUrl} alt="chart" style={{ maxWidth: '100%' }} />
-      )}
-    </Container>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Container sx={{ marginTop: 4 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+          <Typography variant="h4" sx={{ flexGrow: 1 }} gutterBottom>
+            Data Agent React UI
+          </Typography>
+          <IconButton onClick={toggleTheme} color="inherit">
+            {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
+          </IconButton>
+        </Box>
+        <Box sx={{ mb: 2 }}>
+          <FileUpload onUploaded={handleUploaded} />
+        </Box>
+        {datasetId && (
+          <>
+            <DatasetSummary datasetId={datasetId} />
+            <ChartBuilder
+              datasetId={datasetId}
+              columns={columns}
+              onChart={(url) => setChartUrl(url)}
+            />
+            {chartUrl && (
+              <img src={chartUrl} alt="chart" style={{ maxWidth: '100%' }} />
+            )}
+            <HistoryPanel datasetId={datasetId} />
+          </>
+        )}
+      </Container>
+    </ThemeProvider>
   );
 }

--- a/frontend/src/ChartBuilder.tsx
+++ b/frontend/src/ChartBuilder.tsx
@@ -1,0 +1,169 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { fetchChart } from './api';
+
+const CHART_TYPES = [
+  'line',
+  'bar',
+  'hist',
+  'box',
+  'scatter',
+  'facet_line',
+  'facet_bar',
+  'facet_hist',
+];
+
+export interface ChartPreset {
+  name: string;
+  spec: any;
+}
+
+interface Props {
+  datasetId: string;
+  columns: string[];
+  onChart: (url: string) => void;
+}
+
+const PRESET_KEY = 'chartPresets';
+
+export default function ChartBuilder({ datasetId, columns, onChart }: Props) {
+  const [chartType, setChartType] = useState('bar');
+  const [xField, setXField] = useState('');
+  const [yField, setYField] = useState('');
+  const [facetField, setFacetField] = useState('');
+  const [presetName, setPresetName] = useState('');
+  const [presets, setPresets] = useState<ChartPreset[]>(
+    JSON.parse(localStorage.getItem(PRESET_KEY) || '[]')
+  );
+
+  const buildSpec = () => {
+    const params: any = {};
+    if (xField) params.x = xField;
+    if (yField) params.y = yField;
+    if (chartType.startsWith('facet_') && facetField) params.facet = facetField;
+    return { type: chartType, params };
+  };
+
+  const handleBuild = async () => {
+    const spec = buildSpec();
+    const url = await fetchChart(datasetId, spec);
+    onChart(url);
+  };
+
+  const handleSave = () => {
+    const spec = buildSpec();
+    const next = [...presets, { name: presetName || `Preset ${presets.length + 1}`, spec }];
+    setPresets(next);
+    localStorage.setItem(PRESET_KEY, JSON.stringify(next));
+    setPresetName('');
+  };
+
+  const handlePresetSelect = (e: any) => {
+    const p = presets.find((pr) => pr.name === e.target.value);
+    if (p) {
+      setChartType(p.spec.type);
+      setXField(p.spec.params?.x || '');
+      setYField(p.spec.params?.y || '');
+      setFacetField(p.spec.params?.facet || '');
+    }
+  };
+
+  return (
+    <Box sx={{ my: 2 }}>
+      <Typography variant="h6">Chart Builder</Typography>
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 1 }}>
+        <Select value={chartType} onChange={(e) => setChartType(e.target.value)} size="small">
+          {CHART_TYPES.map((t) => (
+            <MenuItem key={t} value={t}>
+              {t}
+            </MenuItem>
+          ))}
+        </Select>
+        <Select
+          value={xField}
+          onChange={(e) => setXField(e.target.value)}
+          displayEmpty
+          size="small"
+        >
+          <MenuItem value="">
+            <em>X</em>
+          </MenuItem>
+          {columns.map((c) => (
+            <MenuItem key={c} value={c}>
+              {c}
+            </MenuItem>
+          ))}
+        </Select>
+        <Select
+          value={yField}
+          onChange={(e) => setYField(e.target.value)}
+          displayEmpty
+          size="small"
+        >
+          <MenuItem value="">
+            <em>Y</em>
+          </MenuItem>
+          {columns.map((c) => (
+            <MenuItem key={c} value={c}>
+              {c}
+            </MenuItem>
+          ))}
+        </Select>
+        {chartType.startsWith('facet_') && (
+          <Select
+            value={facetField}
+            onChange={(e) => setFacetField(e.target.value)}
+            displayEmpty
+            size="small"
+          >
+            <MenuItem value="">
+              <em>Facet</em>
+            </MenuItem>
+            {columns.map((c) => (
+              <MenuItem key={c} value={c}>
+                {c}
+              </MenuItem>
+            ))}
+          </Select>
+        )}
+        <Button variant="contained" onClick={handleBuild} size="small">
+          Build
+        </Button>
+      </Box>
+      <Box sx={{ mt: 2, display: 'flex', gap: 1, alignItems: 'center' }}>
+        <Select
+          value=""
+          onChange={handlePresetSelect}
+          displayEmpty
+          size="small"
+          sx={{ minWidth: 120 }}
+        >
+          <MenuItem value="">
+            <em>Load preset</em>
+          </MenuItem>
+          {presets.map((p) => (
+            <MenuItem key={p.name} value={p.name}>
+              {p.name}
+            </MenuItem>
+          ))}
+        </Select>
+        <TextField
+          value={presetName}
+          onChange={(e) => setPresetName(e.target.value)}
+          placeholder="Preset name"
+          size="small"
+        />
+        <Button onClick={handleSave} variant="outlined" size="small">
+          Save Preset
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/DatasetSummary.tsx
+++ b/frontend/src/DatasetSummary.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { fetchSummary, Summary } from './api';
+import {
+  Box,
+  Typography,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from '@mui/material';
+
+interface Props {
+  datasetId: string;
+}
+
+export default function DatasetSummary({ datasetId }: Props) {
+  const [summary, setSummary] = useState<Summary | null>(null);
+
+  useEffect(() => {
+    fetchSummary(datasetId)
+      .then(setSummary)
+      .catch(() => setSummary(null));
+  }, [datasetId]);
+
+  if (!summary) return null;
+
+  return (
+    <Box sx={{ my: 2 }}>
+      <Typography variant="h6">Dataset Summary</Typography>
+      <Typography variant="body2">Rows: {summary.rows}</Typography>
+      <Table size="small" sx={{ mt: 1 }}>
+        <TableHead>
+          <TableRow>
+            <TableCell>Column</TableCell>
+            <TableCell>Type</TableCell>
+            <TableCell>Nulls</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {summary.columns.map((col) => (
+            <TableRow key={col}>
+              <TableCell>{col}</TableCell>
+              <TableCell>{summary.dtypes[col]}</TableCell>
+              <TableCell>{summary.null_counts[col]}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}

--- a/frontend/src/HistoryPanel.tsx
+++ b/frontend/src/HistoryPanel.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { askQuestion, runCode, RunResult } from './api';
+import { Box, Button, TextField, Typography } from '@mui/material';
+
+interface Item {
+  question: string;
+  timestamp: number;
+}
+
+interface Props {
+  datasetId: string;
+}
+
+const HISTORY_KEY = 'promptHistory';
+
+export default function HistoryPanel({ datasetId }: Props) {
+  const [question, setQuestion] = useState('');
+  const [history, setHistory] = useState<Item[]>(
+    JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]')
+  );
+  const [output, setOutput] = useState<RunResult | null>(null);
+
+  useEffect(() => {
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+  }, [history]);
+
+  const runPrompt = async () => {
+    if (!question.trim()) return;
+    const { code } = await askQuestion(datasetId, question);
+    const result = await runCode(datasetId, code);
+    setOutput(result);
+    setHistory([{ question, timestamp: Date.now() }, ...history]);
+    setQuestion('');
+  };
+
+  return (
+    <Box sx={{ my: 2 }}>
+      <Typography variant="h6">Prompt Runner</Typography>
+      <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+        <TextField
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder="Ask a question"
+          size="small"
+          fullWidth
+        />
+        <Button onClick={runPrompt} variant="contained" size="small">
+          Run
+        </Button>
+      </Box>
+      {output && (
+        <Box sx={{ mt: 1 }}>
+          <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+            {output.stdout}
+          </Typography>
+          {output.images.map((img, idx) => (
+            <img
+              key={idx}
+              src={`data:image/png;base64,${img}`}
+              alt="img"
+              style={{ maxWidth: '100%', marginTop: 4 }}
+            />
+          ))}
+        </Box>
+      )}
+      <Box sx={{ mt: 2 }}>
+        <Typography variant="subtitle1">History</Typography>
+        {history.map((h) => (
+          <Typography key={h.timestamp} variant="body2">
+            {new Date(h.timestamp).toLocaleString()}: {h.question}
+          </Typography>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -18,3 +18,49 @@ export async function fetchChart(dsId: string, spec: any): Promise<string> {
   const blob = await res.blob();
   return URL.createObjectURL(blob);
 }
+
+export interface Summary {
+  rows: number;
+  columns: string[];
+  dtypes: Record<string, string>;
+  null_counts: Record<string, number>;
+}
+
+export async function fetchSummary(dsId: string): Promise<Summary> {
+  const res = await fetch(`${API_BASE}/summary/${dsId}`);
+  if (!res.ok) throw new Error('Summary failed');
+  return res.json();
+}
+
+export async function askQuestion(
+  dsId: string,
+  question: string
+): Promise<{ intent: string; code: string }> {
+  const res = await fetch(`${API_BASE}/nl2code/${dsId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ question }),
+  });
+  if (!res.ok) throw new Error('LLM failed');
+  return res.json();
+}
+
+export interface RunResult {
+  stdout: string;
+  tables: string[];
+  images: string[];
+  texts: string[];
+}
+
+export async function runCode(
+  dsId: string,
+  code: string
+): Promise<RunResult> {
+  const res = await fetch(`${API_BASE}/run_code/${dsId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  });
+  if (!res.ok) throw new Error('Run failed');
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- implement API helpers for summary, NL questions and code execution
- add DatasetSummary, ChartBuilder, and HistoryPanel components
- wire dark/light theme toggle and preset saving in the UI
- expand App to use new components
- include MUI icon dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6880936dcf5c8329b74b32fef8406553