### PR TITLE
Add Docker deployment with persistent volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,29 @@ docker compose up --build
 ```
 
 Backend will be available at [http://localhost:8000](http://localhost:8000)
-and the React UI at [http://localhost:3000](http://localhost:3000)
+and the React UI at [http://localhost:3000](http://localhost:3000). The optional
+`proxy` service exposes both on [http://localhost:8080](http://localhost:8080).
 
-### 6.3 Local venv (no Docker)
+### 6.3 Production build and compose
+
+1. Build the React frontend which will generate static files served by Nginx:
+
+   ```bash
+   cd frontend
+   npm install
+   npm run build
+   ```
+
+2. Start all services including the reverse proxy:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   Uploaded datasets are persisted under the `data_files` volume and can be
+   configured through environment variables defined in `docker-compose.yml`.
+
+### 6.4 Local venv (no Docker)
 
 ```bash
 python -m venv .venv
@@ -113,7 +133,7 @@ uvicorn app.api:app --reload
 cd frontend && npm install && npm run dev
 ```
 
-### 6.4 Makefile Shortcuts
+### 6.5 Makefile Shortcuts
 
 ```bash
 # run local app with venv
@@ -128,7 +148,7 @@ make docker
 ```
 
 
-### 6.5 FastAPI server
+### 6.6 FastAPI server
 
 ```bash
 uvicorn app.api:app --reload
@@ -136,7 +156,7 @@ uvicorn app.api:app --reload
 
 This exposes endpoints like `/upload`, `/summary/{id}`, `/chart/{id}`, `/nl2code/{id}` and `/run_code/{id}`.
 
-### 6.6 Running tests
+### 6.7 Running tests
 
 Install the runtime and dev requirements first:
 

--- a/data-agent/Dockerfile.api
+++ b/data-agent/Dockerfile.api
@@ -3,4 +3,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app ./app
+ENV DATA_DIR=/data
+ENV DB_FILE=/data/datasets.db
+RUN mkdir -p "$DATA_DIR"
 CMD ["uvicorn", "app.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/data-agent/app/api.py
+++ b/data-agent/app/api.py
@@ -90,7 +90,7 @@ async def upload(file: UploadFile = File(...)) -> UploadResponse:
     ext = Path(file.filename).suffix.lstrip(".")
     if ext not in settings.allowed_file_types:
         return JSONResponse(status_code=400, content={"error": "file type not allowed"})
-    ds_path = Path("data")
+    ds_path = Path(settings.data_dir)
     ds_path.mkdir(exist_ok=True)
     ds_id = str(uuid.uuid4())
     path = ds_path / f"{ds_id}_{Path(file.filename).name}"

--- a/data-agent/app/core/config.py
+++ b/data-agent/app/core/config.py
@@ -12,6 +12,8 @@ class Settings(BaseSettings):
     allowed_file_types: List[str] = Field(default_factory=lambda: ["csv", "xlsx"], env="ALLOWED_FILE_TYPES")
     log_level: str = Field("INFO", env="LOG_LEVEL")
     safe_exec_mem_mb: int = Field(200, env="SAFE_EXEC_MEM_MB")
+    data_dir: str = Field("data", env="DATA_DIR")
+    db_file: str = Field("datasets.db", env="DB_FILE")
 
     class Config:
         case_sensitive = False

--- a/data-agent/app/core/file_loader.py
+++ b/data-agent/app/core/file_loader.py
@@ -6,7 +6,7 @@ from .config import settings
 
 import pandas as pd
 
-DATA_DIR = Path(os.environ.get("DATA_DIR", "data"))
+DATA_DIR = Path(os.environ.get("DATA_DIR", settings.data_dir))
 
 
 def _maybe_cache(file: IO[bytes], name: str) -> None:

--- a/data-agent/app/core/storage.py
+++ b/data-agent/app/core/storage.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-DB_FILE = Path(__file__).resolve().parents[2] / "datasets.db"
+from .config import settings
+
+DB_FILE = Path(settings.db_file)
 DB_FILE.parent.mkdir(exist_ok=True)
 
 

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    location /api/ {
+        proxy_pass http://api:8000/;
+    }
+    location / {
+        proxy_pass http://frontend:80/;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,28 @@ services:
     build:
       context: ./data-agent
       dockerfile: Dockerfile.api
+    environment:
+      - DATA_DIR=/data
+      - DB_FILE=/data/datasets.db
+      - MAX_FILE_SIZE=5242880
+      - ALLOWED_FILE_TYPES=csv,xlsx
     volumes:
-      - ./data-agent/app:/app/app
+      - data_files:/data
     ports:
       - "8000:8000"
   frontend:
     build: ./frontend
     ports:
       - "3000:80"
+  proxy:
+    image: nginx:alpine
+    volumes:
+      - ./deploy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - api
+      - frontend
+    ports:
+      - "8080:80"
   ollama:
     image: ollama/ollama:latest
     restart: unless-stopped
@@ -20,4 +34,5 @@ services:
     volumes:
       - ollama_data:/root/.ollama
 volumes:
+  data_files:
   ollama_data:


### PR DESCRIPTION
## Summary
- support DATA_DIR and DB_FILE in configuration
- persist data and add Nginx reverse proxy via docker-compose
- create nginx config
- document production build and compose workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - pandas, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6880963b24dc832981a3bf365d5231ac