### PR TITLE
Add offline Windows deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,10 @@ the development server.
 
 Happy building.
 
+---
+
+## Offline Deployment on Windows
+
+For step-by-step instructions to run the stack without internet access,
+see [docs/OFFLINE_WINDOWS.md](docs/OFFLINE_WINDOWS.md).
+

--- a/data-agent/Dockerfile.api
+++ b/data-agent/Dockerfile.api
@@ -1,7 +1,11 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY wheels /wheels
+RUN if [ -d /wheels ]; \
+    then pip install --no-index --find-links /wheels -r requirements.txt; \
+    else pip install --no-cache-dir -r requirements.txt; \
+    fi
 COPY app ./app
 ENV DATA_DIR=/data
 ENV DB_FILE=/data/datasets.db

--- a/docs/OFFLINE_WINDOWS.md
+++ b/docs/OFFLINE_WINDOWS.md
@@ -1,0 +1,104 @@
+# Offline Deployment Guide for Dummies (Windows Server)
+
+This guide walks through running the Data Summarization & Charting Agent on an
+**air‑gapped** Windows Server machine using Docker. Every step is spelled out so
+that even first‑time Docker users can follow along.
+
+## 1. Prepare on an Internet‑Connected Machine
+
+1. **Install Docker Desktop** on any machine with internet access.
+2. **Clone this repository** and open a terminal in the repo root.
+3. Download all container images you will need:
+   ```powershell
+   docker pull python:3.11-slim
+   docker pull node:20-alpine
+   docker pull nginx:alpine
+   docker pull ollama/ollama:latest
+   ```
+4. Save these images to tar archives so you can move them offline:
+   ```powershell
+   docker save -o python.tar python:3.11-slim
+   docker save -o node.tar node:20-alpine
+   docker save -o nginx.tar nginx:alpine
+   docker save -o ollama.tar ollama/ollama:latest
+   ```
+5. Create the directory `wheels` inside `data-agent/` and download Python
+   dependencies into it:
+   ```powershell
+   mkdir data-agent\wheels
+   pip download -r data-agent\requirements.txt -d data-agent\wheels
+   ```
+6. (Optional) Cache npm packages for the frontend build:
+   ```powershell
+   mkdir frontend\npm_cache
+   npm install --ignore-scripts --cache ./frontend/npm_cache
+   ```
+7. Copy the entire repository folder together with the `*.tar` files to your
+   offline Windows Server machine (USB drive or other secure method).
+
+## 2. Set Up the Offline Windows Server
+
+1. **Install Docker** on the Windows Server. Docker Desktop or Docker Engine is
+   fine. Reboot if required.
+2. Load the images you previously saved:
+   ```powershell
+   docker load -i python.tar
+   docker load -i node.tar
+   docker load -i nginx.tar
+   docker load -i ollama.tar
+   ```
+3. Ensure Docker is working by running `docker images`.
+
+## 3. Build the Containers Offline
+
+1. Open PowerShell and change to the repository directory.
+2. Build the API container:
+   ```powershell
+   cd data-agent
+   docker build -t data-agent-api .
+   cd ..
+   ```
+   The Dockerfile checks for a local `wheels` folder and installs packages from
+   there without contacting the internet.
+3. Build the frontend container:
+   ```powershell
+   cd frontend
+   docker build -t data-agent-frontend .
+   cd ..
+   ```
+   If you created the optional `npm_cache` directory, the build will run in
+   offline mode.
+
+## 4. Start the Stack
+
+1. In the repo root run:
+   ```powershell
+   docker compose up
+   ```
+2. The API will listen on port `8000` and the React UI on `3000`. The optional
+   `proxy` service exposes both on `http://localhost:8080`.
+3. To stop everything press `Ctrl+C` and then run `docker compose down`.
+
+## 5. Common Hurdles
+
+- **Port already in use** – change the ports in `docker-compose.yml` if 8000 or
+  3000 are taken.
+- **File access denied** – ensure your current user has permission to write to
+  the project directory where Docker stores data volumes.
+- **Image not found** – verify that you loaded all `*.tar` files with
+  `docker load`.
+- **Package install fails during build** – make sure the `wheels` directory
+  contains all `.whl` files from `pip download` and that you preserved directory
+  structure when copying.
+- **Frontend build errors offline** – if you skipped the optional npm cache,
+  Node will try to reach the internet. Create the cache as described in section
+  1 step 6.
+
+## 6. Updating the Application
+
+When you have internet access again, repeat the preparation steps on an online
+machine to fetch updated images or dependencies, then copy them to the server and
+rebuild.
+
+That's it! You now have a completely offline Dockerized deployment running on
+Windows Server.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,12 @@ FROM node:20-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json* tsconfig.json vite.config.js ./
 COPY src ./src
-RUN npm ci && npm run build
+COPY npm_cache /npm_cache
+RUN if [ -d /npm_cache ]; \
+    then npm ci --offline --cache /npm_cache; \
+    else npm ci; \
+    fi \
+    && npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- support offline build of API and frontend images
- document step-by-step offline deployment for Windows Server
- link to new doc from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68809897ef2c83299394fd7cc43b10e4