### PR TITLE
Improve offline deployment config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Environment configuration for Data Agent
+DATA_DIR=/data
+DB_FILE=/data/datasets.db
+MAX_FILE_SIZE=5242880
+ALLOWED_FILE_TYPES=csv,xlsx
+API_PORT=8000
+FRONTEND_PORT=3000
+PROXY_PORT=8080
+OLLAMA_PORT=11434
+OLLAMA_URL=http://localhost:11434/api
+LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 node_modules/
 frontend/node_modules/
 frontend/dist/
+.env

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ and the React UI at [http://localhost:3000](http://localhost:3000). The optional
    docker compose up --build
    ```
 
-   Uploaded datasets are persisted under the `data_files` volume and can be
-   configured through environment variables defined in `docker-compose.yml`.
+   Uploaded datasets are persisted under the `data_files` volume. Runtime
+   configuration is read from a `.env` file referenced by `docker-compose.yml`.
 
 ### 6.4 Local venv (no Docker)
 

--- a/data-agent/app/core/llm_driver.py
+++ b/data-agent/app/core/llm_driver.py
@@ -14,7 +14,7 @@ import requests  # type: ignore
 # ---------------------------------------------------------------------
 # If running inside Docker and Ollama runs on host:
 # OLLAMA_URL = "http://host.docker.internal:11434/api"
-OLLAMA_URL = "http://localhost:11434/api"
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434/api")
 
 PREFERRED_MODELS: List[str] = [
     "mistral:7b-instruct",

--- a/data-agent/app/core/safe_exec.py
+++ b/data-agent/app/core/safe_exec.py
@@ -1,2 +1,0 @@
-"""Backward compatible wrapper for safe_exec service."""
-from ..services.safe_exec import *  # noqa: F401,F403

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,18 +5,18 @@ services:
       context: ./data-agent
       dockerfile: Dockerfile.api
     environment:
-      - DATA_DIR=/data
-      - DB_FILE=/data/datasets.db
-      - MAX_FILE_SIZE=5242880
-      - ALLOWED_FILE_TYPES=csv,xlsx
+      DATA_DIR: ${DATA_DIR:-/data}
+      DB_FILE: ${DB_FILE:-/data/datasets.db}
+      MAX_FILE_SIZE: ${MAX_FILE_SIZE:-5242880}
+      ALLOWED_FILE_TYPES: ${ALLOWED_FILE_TYPES:-csv,xlsx}
     volumes:
-      - data_files:/data
+      - data_files:${DATA_DIR:-/data}
     ports:
-      - "8000:8000"
+      - "${API_PORT:-8000}:8000"
   frontend:
     build: ./frontend
     ports:
-      - "3000:80"
+      - "${FRONTEND_PORT:-3000}:80"
   proxy:
     image: nginx:alpine
     volumes:
@@ -25,12 +25,12 @@ services:
       - api
       - frontend
     ports:
-      - "8080:80"
+      - "${PROXY_PORT:-8080}:80"
   ollama:
     image: ollama/ollama:latest
     restart: unless-stopped
     ports:
-      - "11434:11434"
+      - "${OLLAMA_PORT:-11434}:11434"
     volumes:
       - ollama_data:/root/.ollama
 volumes:

--- a/docs/OFFLINE_WINDOWS.md
+++ b/docs/OFFLINE_WINDOWS.md
@@ -75,9 +75,11 @@ that even first‑time Docker users can follow along.
    ```powershell
    docker compose up
    ```
-2. The API will listen on port `8000` and the React UI on `3000`. The optional
+2. Copy `.env.example` to `.env` if you need to tweak ports or paths. The
+   compose file reads all configuration from this file.
+3. The API will listen on port `8000` and the React UI on `3000`. The optional
    `proxy` service exposes both on `http://localhost:8080`.
-3. To stop everything press `Ctrl+C` and then run `docker compose down`.
+4. To stop everything press `Ctrl+C` and then run `docker compose down`.
 
 ## 5. Common Hurdles
 

--- a/tests/test_safe_exec.py
+++ b/tests/test_safe_exec.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.core.safe_exec import _analyze, run
+from app.services.safe_exec import _analyze, run
 
 
 def test_analyze_disallows_import():


### PR DESCRIPTION
## Summary
- add `.env.example` for environment variables
- reference `.env` file in README and offline Windows guide
- use env var for `OLLAMA_URL`
- externalize compose configuration with defaults
- ignore local `.env`
- clean up safe exec alias and update tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68825856f3508329b33ae035968c8010