### PR TITLE
Add dev and offline docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,13 @@ Happy building.
 
 ---
 
-## Offline Deployment on Windows
 
-For step-by-step instructions to run the stack without internet access,
-see [docs/OFFLINE_WINDOWS.md](docs/OFFLINE_WINDOWS.md).
+## Offline Deployment
+
+Instructions for air-gapped setups are provided for both Windows and Linux/macOS.
+
+- [docs/OFFLINE_WINDOWS.md](docs/OFFLINE_WINDOWS.md) – Windows specific steps.
+- [docs/OFFLINE_DOCKER.md](docs/OFFLINE_DOCKER.md) – generic Docker workflow.
 
 Additional UI tips are available in [docs/UI_BEST_PRACTICES.md](docs/UI_BEST_PRACTICES.md).
 

--- a/data-agent/requirements.txt
+++ b/data-agent/requirements.txt
@@ -4,3 +4,6 @@ numpy>=1.26
 openpyxl>=3.1     # lets pandas read .xlsx
 reportlab>=4.0
 python-pptx>=0.6
+fastapi>=0.110
+uvicorn[standard]>=0.29
+requests>=2.32

--- a/docs/DEVELOPER_SETUP.md
+++ b/docs/DEVELOPER_SETUP.md
@@ -1,0 +1,84 @@
+# Developer Setup Guide for Dummies
+
+This document explains how to run and develop the Data Agent locally.
+It assumes minimal knowledge of Python and Docker.
+
+## 1. Requirements
+
+- Python 3.11 installed on your system.
+- `git` command line tools.
+- (Optional) Docker if you want to build the containers.
+
+## 2. Clone the repository
+
+```bash
+git clone https://github.com/your-org/data-agent.git
+cd data-agent
+```
+
+## 3. Create a virtual environment
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r data-agent/requirements.txt -r requirements-dev.txt
+```
+
+The first command creates an isolated Python environment so that
+packages do not interfere with your system. The second activates it and
+installs all runtime and development dependencies.
+
+## 4. Run the API server
+
+While the virtual environment is active, start the FastAPI server:
+
+```bash
+uvicorn app.api:app --reload
+```
+
+Navigate to `http://localhost:8000/docs` to see the interactive API docs.
+The `--reload` flag automatically restarts the server when you modify
+files under `app/`.
+
+## 5. Frontend development
+
+The React UI lives in the `frontend/` folder.
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The development server listens on port `5173` by default. Visit
+`http://localhost:5173` to open the UI.
+
+## 6. Running tests
+
+From the repository root run:
+
+```bash
+PYTHONPATH=. pytest -q
+```
+
+You may need to activate the virtual environment first.
+
+## 7. Useful Makefile commands
+
+A few helper targets are defined in the `Makefile`:
+
+- `make dev` – start the API with reload (requires venv).
+- `make lint` – run code style checks using pre-commit.
+- `make fmt` – auto-format the code base.
+- `make docker` – build and run the Docker compose stack.
+
+## 8. Common issues
+
+- **Missing dependencies** – double check that you activated the
+  virtual environment before installing packages.
+- **Port already in use** – change the `API_PORT` or `FRONTEND_PORT`
+  environment variables in the `.env` file.
+- **Tests cannot import modules** – make sure `PYTHONPATH` includes the
+  repository root (`.`) when running pytest.
+
+Happy hacking!

--- a/docs/OFFLINE_DOCKER.md
+++ b/docs/OFFLINE_DOCKER.md
@@ -1,0 +1,86 @@
+# Offline Deployment Guide (Linux/macOS)
+
+This document explains how to run the Docker stack on a machine
+without internet access. The process is similar to the Windows steps but
+uses standard Linux commands.
+
+## 1. Prepare on a machine with internet
+
+1. Install Docker on an online machine.
+2. Clone this repository and switch into it.
+3. Pull all required container images:
+   ```bash
+   docker pull python:3.11-slim
+   docker pull node:20-alpine
+   docker pull nginx:alpine
+   docker pull ollama/ollama:latest
+   ```
+4. Save the images to tar files for transfer:
+   ```bash
+   docker save -o python.tar python:3.11-slim
+   docker save -o node.tar node:20-alpine
+   docker save -o nginx.tar nginx:alpine
+   docker save -o ollama.tar ollama/ollama:latest
+   ```
+5. Download Python packages to `data-agent/wheels`:
+   ```bash
+   mkdir -p data-agent/wheels
+   pip download -r data-agent/requirements.txt -d data-agent/wheels
+   ```
+6. (Optional) cache npm packages for the frontend:
+   ```bash
+   mkdir -p frontend/npm_cache
+   npm install --ignore-scripts --cache ./frontend/npm_cache
+   ```
+7. Copy the repository along with all `*.tar` files to the offline
+   machine using a USB drive or other secure method.
+
+## 2. Set up the offline host
+
+1. Install Docker Engine on the target machine.
+2. Load the saved images:
+   ```bash
+   docker load -i python.tar
+   docker load -i node.tar
+   docker load -i nginx.tar
+   docker load -i ollama.tar
+   ```
+3. Confirm the images are available with `docker images`.
+
+## 3. Build and run
+
+1. Build the API container (installs packages from the `wheels` folder):
+   ```bash
+   cd data-agent
+   docker build -t data-agent-api .
+   cd ..
+   ```
+2. Build the frontend container:
+   ```bash
+   cd frontend
+   docker build -t data-agent-frontend .
+   cd ..
+   ```
+3. Start the full stack:
+   ```bash
+   docker compose up
+   ```
+   The API listens on port `8000` and the UI on `3000`. You can also use
+   the optional `proxy` service which exposes both through port `8080`.
+
+## 4. Common problems
+
+- **"package not found" during build** – ensure the `wheels` directory
+  contains all required `.whl` files from the online machine.
+- **Docker cannot access files** – verify that the repository path is
+  readable by your user and that SELinux/AppArmor is not blocking
+  container mounts.
+- **Ports already used** – change the values in `.env` and restart
+  `docker compose`.
+- **Ollama model missing** – on the online machine run
+  `ollama pull mistral:7b-instruct` (or any model you want) and export it
+  with `ollama export`, then copy the resulting files into the
+  `ollama_data` volume on the offline host.
+
+Once everything is up you can open `http://localhost:8080` (or the
+individual service ports) in your browser.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ dependencies = [
     "numpy>=1.26",
     "openpyxl>=3.1",
     "reportlab>=4.0",
-    "python-pptx>=0.6"
+    "python-pptx>=0.6",
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.29",
+    "requests>=2.32"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- document developer setup steps
- document offline Docker deployment
- update README with links to the new docs
- add missing runtime dependencies for the API

## Testing
- `pip install -r data-agent/requirements.txt -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement pandas>=2.2)*
- `pytest -q` *(fails to import packages)*

------
https://chatgpt.com/codex/tasks/task_e_6882601ff4108329b6693058274b619c