### PR TITLE
Fix offline wheel download docs

### DIFF
--- a/docs/OFFLINE_DOCKER.md
+++ b/docs/OFFLINE_DOCKER.md
@@ -22,10 +22,13 @@ uses standard Linux commands.
    docker save -o nginx.tar nginx:alpine
    docker save -o ollama.tar ollama/ollama:latest
    ```
-5. Download Python packages to `data-agent/wheels`:
+5. Download Linux wheels for Python 3.11 into `data-agent/wheels`.
+   The `--platform` flag ensures the packages match the Docker image
+   (which is Linux based):
    ```bash
    mkdir -p data-agent/wheels
-   pip download -r data-agent/requirements.txt -d data-agent/wheels
+   pip download --platform manylinux2014_x86_64 --python-version 3.11 \
+       --only-binary=:all: -r data-agent/requirements.txt -d data-agent/wheels
    ```
 6. (Optional) cache npm packages for the frontend:
    ```bash

--- a/docs/OFFLINE_WINDOWS.md
+++ b/docs/OFFLINE_WINDOWS.md
@@ -22,11 +22,13 @@ that even first‑time Docker users can follow along.
    docker save -o nginx.tar nginx:alpine
    docker save -o ollama.tar ollama/ollama:latest
    ```
-5. Create the directory `wheels` inside `data-agent/` and download Python
-   dependencies into it:
+5. Create the directory `wheels` inside `data-agent/` and download Linux
+   wheels for Python 3.11. Use the `--platform` option so that the packages
+   work inside the Linux based Docker container:
    ```powershell
    mkdir data-agent\wheels
-   pip download -r data-agent\requirements.txt -d data-agent\wheels
+   pip download --platform manylinux2014_x86_64 --python-version 3.11 \
+       --only-binary=:all: -r data-agent\requirements.txt -d data-agent\wheels
    ```
 6. (Optional) Cache npm packages for the frontend build:
    ```powershell


### PR DESCRIPTION
## Summary
- clarify wheel download instructions for Windows and Docker offline setups

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6882666819b88329bbcea7a58580fa0b