### PR TITLE
Improve Windows docs and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,35 @@
 VENV=.venv
-PYTHON=$(VENV)/bin/python
-PIP=$(VENV)/bin/pip
 
-$(VENV)/bin/activate: requirements-dev.txt data-agent/requirements.txt
+ifeq ($(OS),Windows_NT)
+    VENV_BIN=$(VENV)/Scripts
+    PYTHON=$(VENV_BIN)/python.exe
+    PIP=$(VENV_BIN)/pip.exe
+    ACTIVATE=$(VENV_BIN)/activate
+else
+    VENV_BIN=$(VENV)/bin
+    PYTHON=$(VENV_BIN)/python
+    PIP=$(VENV_BIN)/pip
+    ACTIVATE=$(VENV_BIN)/activate
+endif
+
+$(ACTIVATE): requirements-dev.txt data-agent/requirements.txt
 	python -m venv $(VENV)
 	$(PIP) install -r data-agent/requirements.txt -r requirements-dev.txt
 	touch $@
 
 .PHONY: dev docker lint fmt test
 
-dev: $(VENV)/bin/activate
-    $(VENV)/bin/uvicorn app.api:app --reload
+dev: $(ACTIVATE)
+	$(VENV_BIN)/uvicorn app.api:app --reload
 
 docker:
 	docker compose up --build
 
 lint:
-	$(VENV)/bin/pre-commit run --files $(shell git ls-files '*.py')
+	$(VENV_BIN)/pre-commit run --files $(shell git ls-files '*.py')
 
 fmt:
-	$(VENV)/bin/pre-commit run ruff-format isort pyproject-fmt --files $(shell git ls-files '*.py' 'pyproject.toml')
+	$(VENV_BIN)/pre-commit run ruff-format isort pyproject-fmt --files $(shell git ls-files '*.py' 'pyproject.toml')
 
-test: $(VENV)/bin/activate
+test: $(ACTIVATE)
 	$(PYTHON) -m pytest

--- a/docs/DEVELOPER_SETUP.md
+++ b/docs/DEVELOPER_SETUP.md
@@ -20,7 +20,12 @@ cd data-agent
 
 ```bash
 python3 -m venv .venv
+# Linux/macOS
 source .venv/bin/activate
+# Windows (cmd)
+.\.venv\Scripts\activate.bat
+# Windows (PowerShell)
+.\.venv\Scripts\Activate.ps1
 pip install -r data-agent/requirements.txt -r requirements-dev.txt
 ```
 
@@ -71,6 +76,11 @@ A few helper targets are defined in the `Makefile`:
 - `make lint` – run code style checks using pre-commit.
 - `make fmt` – auto-format the code base.
 - `make docker` – build and run the Docker compose stack.
+
+On Windows you may need to install `make` separately (e.g. via
+[Chocolatey](https://chocolatey.org/) or the
+[GnuWin](http://gnuwin32.sourceforge.net/packages/make.htm) package) or
+run the commands inside the file manually.
 
 ## 8. Common issues
 


### PR DESCRIPTION
## Summary
- add cross-platform logic to `Makefile`
- document Windows virtualenv activation steps
- mention installing `make` on Windows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688267b35e208329b20213e5c071b414