### PR TITLE
Update docs for PowerShell use

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Teams often need quick exploratory analysis without sending sensitive data to th
 
 ### 6.2 One line Docker run
 
-```bash
+```powershell
 docker compose up --build
 ```
 
@@ -110,7 +110,7 @@ and the React UI at [http://localhost:3000](http://localhost:3000). The optional
 
 1. Build the React frontend which will generate static files served by Nginx:
 
-   ```bash
+   ```powershell
    cd frontend
    npm install
    npm run build
@@ -118,7 +118,7 @@ and the React UI at [http://localhost:3000](http://localhost:3000). The optional
 
 2. Start all services including the reverse proxy:
 
-   ```bash
+   ```powershell
    docker compose up --build
    ```
 
@@ -127,9 +127,9 @@ and the React UI at [http://localhost:3000](http://localhost:3000). The optional
 
 ### 6.4 Local venv (no Docker)
 
-```bash
+```powershell
 python -m venv .venv
-source .venv/Scripts/activate  # Windows: .venv\Scripts\Activate.ps1
+\.\.venv\Scripts\Activate.ps1
 pip install -r data-agent/requirements.txt
 uvicorn app.api:app --reload
 cd frontend && npm install && npm run dev
@@ -137,7 +137,8 @@ cd frontend && npm install && npm run dev
 
 ### 6.5 Makefile Shortcuts
 
-```bash
+# run local app with venv
+```powershell
 # run local app with venv
 make dev
 
@@ -152,7 +153,7 @@ make docker
 
 ### 6.6 FastAPI server
 
-```bash
+```powershell
 uvicorn app.api:app --reload
 ```
 
@@ -162,14 +163,15 @@ This exposes endpoints like `/upload`, `/summary/{id}`, `/chart/{id}`, `/nl2code
 
 Install the runtime and dev requirements first:
 
-```bash
+```powershell
 pip install -r data-agent/requirements.txt -r requirements-dev.txt
 ```
 
 Then execute the test suite with the repository root on the `PYTHONPATH`:
 
-```bash
-PYTHONPATH=. pytest -q
+```powershell
+$env:PYTHONPATH = '.'
+pytest -q
 ```
 
 ---

--- a/docs/DEVELOPER_SETUP.md
+++ b/docs/DEVELOPER_SETUP.md
@@ -11,21 +11,16 @@ It assumes minimal knowledge of Python and Docker.
 
 ## 2. Clone the repository
 
-```bash
+```powershell
 git clone https://github.com/your-org/data-agent.git
 cd data-agent
 ```
 
 ## 3. Create a virtual environment
 
-```bash
-python3 -m venv .venv
-# Linux/macOS
-source .venv/bin/activate
-# Windows (cmd)
-.\.venv\Scripts\activate.bat
-# Windows (PowerShell)
-.\.venv\Scripts\Activate.ps1
+```powershell
+python -m venv .venv
+\.\.venv\Scripts\Activate.ps1
 pip install -r data-agent/requirements.txt -r requirements-dev.txt
 ```
 
@@ -37,7 +32,7 @@ installs all runtime and development dependencies.
 
 While the virtual environment is active, start the FastAPI server:
 
-```bash
+```powershell
 uvicorn app.api:app --reload
 ```
 
@@ -49,7 +44,7 @@ files under `app/`.
 
 The React UI lives in the `frontend/` folder.
 
-```bash
+```powershell
 cd frontend
 npm install
 npm run dev
@@ -62,8 +57,9 @@ The development server listens on port `5173` by default. Visit
 
 From the repository root run:
 
-```bash
-PYTHONPATH=. pytest -q
+```powershell
+$env:PYTHONPATH = '.'
+pytest -q
 ```
 
 You may need to activate the virtual environment first.

--- a/docs/OFFLINE_DOCKER.md
+++ b/docs/OFFLINE_DOCKER.md
@@ -2,21 +2,21 @@
 
 This document explains how to run the Docker stack on a machine
 without internet access. The process is similar to the Windows steps but
-uses standard Linux commands.
+uses PowerShell commands which also work on Linux/macOS via PowerShell Core.
 
 ## 1. Prepare on a machine with internet
 
 1. Install Docker on an online machine.
 2. Clone this repository and switch into it.
 3. Pull all required container images:
-   ```bash
+   ```powershell
    docker pull python:3.11-slim
    docker pull node:20-alpine
    docker pull nginx:alpine
    docker pull ollama/ollama:latest
    ```
 4. Save the images to tar files for transfer:
-   ```bash
+   ```powershell
    docker save -o python.tar python:3.11-slim
    docker save -o node.tar node:20-alpine
    docker save -o nginx.tar nginx:alpine
@@ -25,14 +25,14 @@ uses standard Linux commands.
 5. Download Linux wheels for Python 3.11 into `data-agent/wheels`.
    The `--platform` flag ensures the packages match the Docker image
    (which is Linux based):
-   ```bash
-   mkdir -p data-agent/wheels
+   ```powershell
+   mkdir data-agent/wheels
    pip download --platform manylinux2014_x86_64 --python-version 3.11 \
        --only-binary=:all: -r data-agent/requirements.txt -d data-agent/wheels
    ```
 6. (Optional) cache npm packages for the frontend:
-   ```bash
-   mkdir -p frontend/npm_cache
+   ```powershell
+   mkdir frontend/npm_cache
    npm install --ignore-scripts --cache ./frontend/npm_cache
    ```
 7. Copy the repository along with all `*.tar` files to the offline
@@ -42,7 +42,7 @@ uses standard Linux commands.
 
 1. Install Docker Engine on the target machine.
 2. Load the saved images:
-   ```bash
+   ```powershell
    docker load -i python.tar
    docker load -i node.tar
    docker load -i nginx.tar
@@ -53,19 +53,19 @@ uses standard Linux commands.
 ## 3. Build and run
 
 1. Build the API container (installs packages from the `wheels` folder):
-   ```bash
+   ```powershell
    cd data-agent
    docker build -t data-agent-api .
    cd ..
    ```
 2. Build the frontend container:
-   ```bash
+   ```powershell
    cd frontend
    docker build -t data-agent-frontend .
    cd ..
    ```
 3. Start the full stack:
-   ```bash
+   ```powershell
    docker compose up
    ```
    The API listens on port `8000` and the UI on `3000`. You can also use


### PR DESCRIPTION
## Summary
- update main README to show PowerShell commands
- adjust developer setup guide for PowerShell users
- convert offline Docker instructions to PowerShell syntax

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68826ab810608329afd9708942d03323